### PR TITLE
fix(ci): skip build if commit doesnt have a tag

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -5,17 +5,22 @@ on:
     branches: [dev]
     tags:
       - '*'
-
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event.release.tag_name }}
 
     steps:
       # clone this repo to $GITHUB_WORKSPACE
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Get latest tag
+        id: tag
+        run: |
+          echo "::set-output name={TAG}::{git tag | sort -n | tail -1}"
 
       # run the daily-build script
       - name: Generate the images
@@ -34,3 +39,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: cropped/shabby/*
+          tag_name: ${{steps.tag.outputs.TAG}}


### PR DESCRIPTION
Unfortunately GitHub trigger on push tag also triggers on regular pushes like merges.